### PR TITLE
UI Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ npm run dev
 
 Docker is the easiest way to run the **Foursball REST API**. Run with `docker run -d -p 80:80 foursball/foursball-api`. The OAuth environment variables are ommited from the `docker run` command, so add them in once you have followed the above instructions (e.g. `docker run -d -e GITHUB_ID=[my-id] -e GITHUB_SECRET=[my-secret] -e SERVER_URL=http://127.0.0.1 -p 80:80 foursball-api`).
 
+## UI Proxy
+This API can be run with the [Foursball UI](https://github.com/Foursball/foosball) by proxying all non-API calls to the UI. Use the following environment variables to configure the proxy:
+
+- PROXY_ENABLED (default: false) - Toggle for the proxy
+- PROXY_URL (default: http://localhost:4200) - URL to proxy non-API requests to
+
 ## Running with MySQL
 
 The default database is on disk, so it is recommended to run the **Foursball REST API** with a MySQL DB in production. Use the following environment variables:

--- a/config/globals.js
+++ b/config/globals.js
@@ -1,4 +1,3 @@
 module.exports.globals = {
-
-
+  proxy: 'http://localhost:4200'
 };

--- a/config/globals.js
+++ b/config/globals.js
@@ -1,3 +1,4 @@
 module.exports.globals = {
-  proxy: 'http://localhost:4200'
+  proxy: process.env.PROXY_URL || 'http://localhost:4200',
+  proxyEnabled: process.env.PROXY_ENABLED === undefined ? false : process.env.PROXY_ENABLED === 'true'
 };

--- a/config/http.js
+++ b/config/http.js
@@ -32,7 +32,7 @@ module.exports.http = {
   customMiddleware: function(app) {
     app.use(proxy(sails.config.globals.proxy, {
       filter: function(req, res) {
-        return req.path.match(/^\/(?!(auths|games|leagues|rules|seasons|teams|teamgames|users|userleagues)).*/);
+        return sails.config.globals.proxyEnabled && req.path.match(/^\/(?!(auths|games|leagues|rules|seasons|teams|teamgames|users|userleagues)).*/);
       }
     }));
   }

--- a/config/http.js
+++ b/config/http.js
@@ -1,5 +1,9 @@
+var proxy = require('express-http-proxy');
+
 module.exports.http = {
   middleware: {
+
+    custom: true,
 
     passportInit: require('passport').initialize(),
     passportSession: require('passport').session(),
@@ -16,11 +20,20 @@ module.exports.http = {
             'compress',
             'methodOverride',
             'poweredBy',
+            '$custom',
             'router',
             'www',
             'favicon',
             '404',
             '500'
-          ],
+          ]
+  },
+
+  customMiddleware: function(app) {
+    app.use(proxy(sails.config.globals.proxy, {
+      filter: function(req, res) {
+        return req.path.match(/^\/(?!(auth|game|home|player|team|user)).*/);
+      }
+    }));
   }
 };

--- a/config/http.js
+++ b/config/http.js
@@ -32,7 +32,7 @@ module.exports.http = {
   customMiddleware: function(app) {
     app.use(proxy(sails.config.globals.proxy, {
       filter: function(req, res) {
-        return req.path.match(/^\/(?!(auth|game|home|player|team|user)).*/);
+        return req.path.match(/^\/(?!(auths|games|leagues|rules|seasons|teams|teamgames|users|userleagues)).*/);
       }
     }));
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Rest API for Foursball",
   "dependencies": {
     "ejs": "2.3.4",
+    "express-http-proxy": "^0.11.0",
     "fluent-logger": "^2.2.0",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",


### PR DESCRIPTION
Add a UI proxy toggle for proxying non-API requests to a UI. This will be used when hosting the UI and API separately, but want consolidated authentication to be in the API.